### PR TITLE
Game Polish #2

### DIFF
--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -32,6 +32,7 @@ public class GameManager : MonoBehaviour
         enemyCount = FindObjectsOfType<EnemyHealth>().Length;
         HudManager.Instance.SetupEnemyCount(enemyCount);
         Player.SetActive(true);
+        PauseMenuManager.Instance.ResumeGame();
     }
 
     public void CheckIfWon(GameObject enemy)

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -43,6 +43,7 @@ public class GameManager : MonoBehaviour
         {
             Debug.Log("PLAYER WON");
             CurrentLevel++;
+            Player.GetComponent<PlayerHealth>().InitialiseHealth();
             EndScreenManager.Instance.Setup(true);
         }
     }

--- a/Assets/Scripts/Player/PlayerHealth.cs
+++ b/Assets/Scripts/Player/PlayerHealth.cs
@@ -114,7 +114,7 @@ public class PlayerHealth : MonoBehaviour
         healthIncreaseCoroutine = null;
     }
 
-    private void InitialiseHealth()
+    public void InitialiseHealth()
     {
         currentHealth = maxHealth; // Initialize current health to max health at the start
         lastDamageTime = Time.time; // Initialize the last damage time

--- a/Assets/Scripts/Weapons/WeaponManager.cs
+++ b/Assets/Scripts/Weapons/WeaponManager.cs
@@ -67,7 +67,7 @@ public class WeaponManager : MonoBehaviour
             else if (Input.GetMouseButtonDown(0)) {
                 ActiveWeapon.Fire(ActiveBullet);
             }
-            else if (Input.GetMouseButtonDown(1)) ThrowGrenade();
+            else if (Input.GetKeyDown(KeyCode.Space)) ThrowGrenade();
             else if (Input.GetKeyDown(KeyCode.Alpha1)) SwitchElement(Element.Fire);
             else if (Input.GetKeyDown(KeyCode.Alpha2)) SwitchElement(Element.Lightning);
             else if (Input.GetKeyDown(KeyCode.Alpha3)) SwitchElement(Element.Frost);

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,11 +6,11 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
-    path: Assets/Scenes/LoadingScene.unity
-    guid: b97b04bc0a96a4301a9fcf8bfaa44a8f
-  - enabled: 1
     path: Assets/Scenes/StartScene.unity
     guid: 65358ab2912544b64961ed7888c651d7
+  - enabled: 1
+    path: Assets/Scenes/LoadingScene.unity
+    guid: b97b04bc0a96a4301a9fcf8bfaa44a8f
   - enabled: 1
     path: Assets/Scenes/MainMenuScene.unity
     guid: e7d27b2f38c1d4fc2823c2ee920e4373

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -3,7 +3,7 @@
 --- !u!30 &1
 GraphicsSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 12
+  serializedVersion: 13
   m_Deferred:
     m_Mode: 1
     m_Shader: {fileID: 69, guid: 0000000000000000f000000000000000, type: 0}
@@ -31,6 +31,9 @@ GraphicsSettings:
   m_AlwaysIncludedShaders:
   - {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 16001, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}
@@ -55,3 +58,5 @@ GraphicsSettings:
   m_AlbedoSwatchInfos: []
   m_LightsUseLinearIntensity: 0
   m_LightsUseColorTemperature: 0
+  m_LogWhenShaderIsCompiled: 0
+  m_AllowEnlightenSupportForUpgradedProject: 1


### PR DESCRIPTION
This fixes several last-minute bugs:

- Reset health when the player wins: Currently, when the player wins their health remains depleted in the next level. This resets the health when the player wins.
- Use correct controls for grenade
- Resume game at the start of the level
- Adjust Scene order in Build settings: Currently, the first scene in the Build Settings is the Loading Scene. This causes the Builds to be stuck in the Loading screen, which is not ideal. This changes the first scene to be the Start Scene instead.